### PR TITLE
ClientID, payload config fields and Telwin message parsing added

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Run "bash setup_venv.sh" to create the python environment and install the requir
   * "host": The broker’s hostname/IP
   * "port": The broker’s port
   * "q_length": How many messages are kept before being overwritten
+  * "msg_type": Specify the message payload structure: "string" | "json" // default raw
 ### Example:
 ```json
 {
@@ -33,7 +34,8 @@ Run "bash setup_venv.sh" to create the python environment and install the requir
   "topic": "aranet/358151004965/sensors/6009F3/json/measurements",
   "host": "10.1.8.247",
   "port": 1883,
-  "q_length": 10
+  "q_length": 10,
+  "msg_type": "string" | "json" // default raw
 }
 
 {
@@ -41,6 +43,7 @@ Run "bash setup_venv.sh" to create the python environment and install the requir
   "topic": "aranet/358151004965/sensors/1010EA/json/measurements",
   "host": "10.1.8.247",
   "port": 1883,
-  "q_length": 10
+  "q_length": 10,
+  "msg_type": "string" | "json" // default raw
 }
 ```


### PR DESCRIPTION
The Viam MQTT client now supports a couple more features:

- Adding clientIDs via json configuration clientid
- Parsing message payload via payload which is optional (raw bytes as default), "string", "json" or "telwin"
- Added "Telwin" welding machine message payload parsing